### PR TITLE
Add jwt format tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "preview": "vite preview",
     "check": "svelte-kit sync && svelte-check --tsconfig ./jsconfig.json",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./jsconfig.json --watch",
-    "wrangler": "wrangler"
+    "wrangler": "wrangler",
+    "test": "node --test"
   },
   "devDependencies": {
     "@sveltejs/adapter-cloudflare": "^4.6.1",

--- a/tests/jwt.test.js
+++ b/tests/jwt.test.js
@@ -1,0 +1,15 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { is_jwt_format_valid } from '../src/lib/tools/jwt.js';
+
+test('accepts a well-formed token', () => {
+  const token = 'header123456.payloadtest7890.signature_part';
+  assert.strictEqual(is_jwt_format_valid(token), true);
+});
+
+test('rejects malformed tokens', () => {
+  assert.strictEqual(is_jwt_format_valid(''), false);
+  assert.strictEqual(is_jwt_format_valid('abc.def'), false);
+  assert.strictEqual(is_jwt_format_valid('abc.def.ghi'), false);
+  assert.strictEqual(is_jwt_format_valid('abc.def?.ghi'), false);
+});


### PR DESCRIPTION
## Summary
- add basic token format tests with Node's test runner
- wire up npm test script to use `node --test`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683f415965e4832d897bdb8d1fafb5c8