### PR TITLE
Fix blog posts typographical error

### DIFF
--- a/src/routes/(public)/blog/(posts)/awesome-post/+page.svelte
+++ b/src/routes/(public)/blog/(posts)/awesome-post/+page.svelte
@@ -21,6 +21,6 @@ npm install
 <p>
   Check out more formatting options like lists, headers, and more in <a
     href="https://play.tailwindcss.com/uj1vGACRJA?layout=preview"
-    >the tailwind/typograpy docs</a
+    >the tailwind/typography docs</a
   >.
 </p>

--- a/src/routes/(public)/blog/(posts)/example-post/+page.svelte
+++ b/src/routes/(public)/blog/(posts)/example-post/+page.svelte
@@ -21,6 +21,6 @@ npm install
 <p>
   Check out more formatting options like lists, headers, and more in <a
     href="https://play.tailwindcss.com/uj1vGACRJA?layout=preview"
-    >the tailwind/typograpy docs</a
+    >the tailwind/typography docs</a
   >.
 </p>

--- a/src/routes/(public)/blog/(posts)/wonderful-post/+page.svelte
+++ b/src/routes/(public)/blog/(posts)/wonderful-post/+page.svelte
@@ -21,6 +21,6 @@ npm install
 <p>
   Check out more formatting options like lists, headers, and more in <a
     href="https://play.tailwindcss.com/uj1vGACRJA?layout=preview"
-    >the tailwind/typograpy docs</a
+    >the tailwind/typography docs</a
   >.
 </p>


### PR DESCRIPTION
## Summary
- fix misspelling `typograpy` to `typography` in three blog posts

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_683f41475ea8832d87f6698211fabc28