### PR TITLE
Fix README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ After the steps above, you’ll have a working version like the demo page. Howev
 - Functionality
   - Add actual functionality for your service.
   - Replace the dashboard with real content (`/src/routes/(admin)/dashboard/(menu)/+page.svelte`).
-  - Add necessary domentation pages for your service.
+  - Add necessary documentation pages for your service.
 
 ## Icons
 


### PR DESCRIPTION
## Summary
- correct wording typo in documentation section

## Testing
- `npm run check` *(fails: svelte-kit not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f41548a64832db59d2d5c65c11642