### PR TITLE
Add Tentrait about page

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -18,7 +18,7 @@ export const TURNSTILE_SITEKEY = get_turnstile_sitekey();
 export const WEBSITE_NAME = "Tentrait ltd"; // change this to your own website name
 export const APP_DOMAIN = "justincase.top"; // change this to your own domain
 export const WEBSITE_DESCRIPTION =
-  "The fast, serverless, open source, and full-stack website. Built with SvelteKit, Tailwind, DaisyUI, Stripe and Cloudflare Pages.";
+  "Tentrait delivers secure, scalable infrastructure for businesses operating across complex digital and operational landscapes.";
 
 export const LOGIN_TOKEN_TTL = 1 * 24 * (60 * 60); // the login token (cookie) will last for 1 day, in seconds
 export const MAGIC_LINK_TOKEN_TTL = 1 * 1 * (30 * 60); // the magic login link will last for 30 mins, in seconds

--- a/src/routes/(public)/+layout.svelte
+++ b/src/routes/(public)/+layout.svelte
@@ -15,6 +15,9 @@
         <a href="/blog" class="btn btn-ghost text-base font-bold">Blog</a>
       </li>
       <li class="sm:mx-1">
+        <a href="/about" class="btn btn-ghost text-base font-bold">About</a>
+      </li>
+      <li class="sm:mx-1">
         <a href="/upload" class="btn btn-ghost text-base font-bold">Packet Upload</a>
       </li>
       <li class="sm:mx-1">
@@ -59,6 +62,9 @@
           <a href="/blog" class="btn btn-ghost text-base font-bold">Blog</a>
         </li>
         <li>
+          <a href="/about" class="btn btn-ghost text-base font-bold">About</a>
+        </li>
+        <li>
           <a href="/upload" class="btn btn-ghost text-base font-bold">Packet Upload</a>
         </li>
         <li>
@@ -96,6 +102,7 @@
       <span class="footer-title opacity-80">Explore</span>
       <a class="link link-hover my-1" href="/pricing">Pricing</a>
       <a class="link link-hover my-1" href="/blog">Blog</a>
+      <a class="link link-hover my-1" href="/about">About</a>
       <a class="link link-hover my-1" href="/upload">Packet Upload</a>
       <a class="link link-hover my-1" href="/contact-us">Contact Us</a>
       <a

--- a/src/routes/(public)/about/+page.svelte
+++ b/src/routes/(public)/about/+page.svelte
@@ -1,0 +1,27 @@
+<script>
+  import { WEBSITE_NAME } from "$config";
+</script>
+
+<svelte:head>
+  <title>About - {WEBSITE_NAME}</title>
+  <meta name="description" content="Tentrait delivers secure, scalable infrastructure for businesses operating across complex digital and operational landscapes." />
+</svelte:head>
+
+<div class="container mx-auto px-4 py-8">
+  <article class="prose prose-slate lg:prose-xl mx-auto">
+    <h1 class="font-bold mb-4">Infrastructure. Insight. Integrity.</h1>
+    <p class="text-lg">Bridging IT and OT with Security and Clarity</p>
+    <p>
+      Tentrait delivers secure, scalable infrastructure for businesses operating
+      across complex digital and operational landscapes.
+    </p>
+
+    <h2 class="font-bold mt-8 mb-4">About Tentrait Ltd</h2>
+    <p>
+      Tentrait Ltd is a UK-based infrastructure and cybersecurity consultancy
+      focused on bridging IT and OT environments without disrupting operations.
+      We offer visibility, real-time monitoring, and access segmentation using
+      modern, scalable, cloud-native technologies.
+    </p>
+  </article>
+</div>


### PR DESCRIPTION
## Summary
- create new `About` page with company info
- update navigation menus and footer with link to About page
- update website description in config

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683f564bba94832db6b20f0ee9e445af