### PR TITLE
Add dark mode toggle support

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-theme="light">
   <title></title>
   <head>
     <meta charset="utf-8" />

--- a/src/lib/ThemeToggle.svelte
+++ b/src/lib/ThemeToggle.svelte
@@ -1,0 +1,30 @@
+<script>
+  import { theme } from "$store";
+  import { get } from "svelte/store";
+
+  function toggle() {
+    theme.update((value) => (value === 'light' ? 'dark' : 'light'));
+  }
+</script>
+
+<button class="btn btn-ghost btn-circle" on:click={toggle} aria-label="Toggle theme">
+  {#if $theme === 'dark'}
+    <!-- sun icon -->
+    <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <circle cx="12" cy="12" r="5" stroke="currentColor" stroke-width="2" />
+      <path d="M12 1v2" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
+      <path d="M12 21v2" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
+      <path d="M4.22 4.22l1.42 1.42" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
+      <path d="M18.36 18.36l1.42 1.42" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
+      <path d="M1 12h2" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
+      <path d="M21 12h2" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
+      <path d="M4.22 19.78l1.42-1.42" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
+      <path d="M18.36 5.64l1.42-1.42" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
+    </svg>
+  {:else}
+    <!-- moon icon -->
+    <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z" stroke="currentColor" stroke-width="2" />
+    </svg>
+  {/if}
+</button>

--- a/src/routes/(admin)/dashboard/(menu)/+layout.svelte
+++ b/src/routes/(admin)/dashboard/(menu)/+layout.svelte
@@ -6,6 +6,7 @@
   import { writable } from "svelte/store";
   import { setContext } from "svelte";
   import { sessions_and_activities } from "$store";
+  import ThemeToggle from "$lib/ThemeToggle.svelte";
 
   export let data;
   const { user } = data;
@@ -294,76 +295,10 @@
         </button>
         <ul
           class="dropdown-content bg-base-100 z-[100] menu p-2 border shadow rounded-box w-52"
-        > 
-          <!--  haven't implemented the toggle theme functionality yet
+        >
           <li>
-            <a href="/dashboard" target="_blank" class="text-base">
-              <svg
-                class="h-5 w-5"
-                viewBox="0 0 24 24"
-                stroke="none"
-                fill="none"
-              >
-                <circle
-                  cx="12"
-                  cy="12"
-                  r="5"
-                  stroke="currentColor"
-                  stroke-width="2"
-                />
-                <path
-                  d="M12 2V4"
-                  stroke="currentColor"
-                  stroke-width="2"
-                  stroke-linecap="round"
-                />
-                <path
-                  d="M12 20V22"
-                  stroke="currentColor"
-                  stroke-width="2"
-                  stroke-linecap="round"
-                />
-                <path
-                  d="M4 12L2 12"
-                  stroke="currentColor"
-                  stroke-width="2"
-                  stroke-linecap="round"
-                />
-                <path
-                  d="M22 12L20 12"
-                  stroke="currentColor"
-                  stroke-width="2"
-                  stroke-linecap="round"
-                />
-                <path
-                  d="M19.7778 4.22266L17.5558 6.25424"
-                  stroke="currentColor"
-                  stroke-width="2"
-                  stroke-linecap="round"
-                />
-                <path
-                  d="M4.22217 4.22266L6.44418 6.25424"
-                  stroke="currentColor"
-                  stroke-width="2"
-                  stroke-linecap="round"
-                />
-                <path
-                  d="M6.44434 17.5557L4.22211 19.7779"
-                  stroke="currentColor"
-                  stroke-width="2"
-                  stroke-linecap="round"
-                />
-                <path
-                  d="M19.7778 19.7773L17.5558 17.5551"
-                  stroke="currentColor"
-                  stroke-width="2"
-                  stroke-linecap="round"
-                />
-              </svg>
-              Toggle theme
-            </a>
+            <ThemeToggle />
           </li>
-          -->
           <li>
             <!-- TODO: /doc -->
             <a href="/dashboard" class="text-base">

--- a/src/routes/(public)/+layout.svelte
+++ b/src/routes/(public)/+layout.svelte
@@ -1,6 +1,7 @@
 <script>
   import "$appcss";
   import { WEBSITE_NAME } from "$config";
+  import ThemeToggle from "$lib/ThemeToggle.svelte";
 </script>
 
 <div class="navbar bg-base-100 container mx-auto">
@@ -30,11 +31,12 @@
         >
       </li>
       <li class="sm:mx-1">
-        <a href="/sign-up" class="btn btn-primary text-base font-bold"
-          >Sign Up</a
-        >
+        <a href="/sign-up" class="btn btn-primary text-base font-bold">Sign Up</a>
       </li>
-    </ul>
+      <li class="sm:mx-1">
+        <ThemeToggle />
+      </li>
+      </ul>
     <div class="dropdown dropdown-end sm:hidden">
       <!-- svelte-ignore a11y-label-has-associated-control -->
       <!-- svelte-ignore a11y-no-noninteractive-tabindex -->
@@ -79,9 +81,10 @@
           >
         </li>
         <li>
-          <a href="/sign-up" class="btn btn-primary text-base font-bold"
-            >Sign Up</a
-          >
+          <a href="/sign-up" class="btn btn-primary text-base font-bold">Sign Up</a>
+        </li>
+        <li>
+          <ThemeToggle />
         </li>
       </ul>
     </div>

--- a/src/store.js
+++ b/src/store.js
@@ -1,4 +1,5 @@
 import { writable } from "svelte/store";
+import { browser } from "$app/environment";
 
 /* user's all login_sessions and past activities, to show in /dashboard/sessions page */
 export const sessions_and_activities = writable({
@@ -6,3 +7,24 @@ export const sessions_and_activities = writable({
   activities: [],
   fetched_at: null,
 });
+
+// theme store to toggle between light and dark mode
+let initial_theme = 'light';
+if (browser) {
+  const saved = localStorage.getItem('theme');
+  if (saved) {
+    initial_theme = saved;
+    document.documentElement.setAttribute('data-theme', saved);
+  } else {
+    document.documentElement.setAttribute('data-theme', 'light');
+  }
+}
+
+export const theme = writable(initial_theme);
+
+if (browser) {
+  theme.subscribe((value) => {
+    localStorage.setItem('theme', value);
+    document.documentElement.setAttribute('data-theme', value);
+  });
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -26,6 +26,7 @@ export default {
           "error": "#b91c1c",
         },
       },
+      'dark',
     ],
   },
 };


### PR DESCRIPTION
## Summary
- add theme store with persistence
- create ThemeToggle component
- update public and admin layouts to include ThemeToggle
- enable DaisyUI dark theme
- set default theme attribute in app template

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683f59938558832d92710514c81c88c1