### PR TITLE
Update pages to highlight UK security compliance benefits

### DIFF
--- a/src/routes/(admin)/new-password/+page.svelte
+++ b/src/routes/(admin)/new-password/+page.svelte
@@ -123,7 +123,8 @@
       <br />
 
       <div>
-        <h1 class="text-xl font-bold mb-6">Create New Password</h1>
+        <h1 class="text-xl font-bold mb-2">Create New Password</h1>
+        <p class="text-sm mb-4">Strong passwords keep your data safe and compliant.</p>
         <form
           class="form-widget"
           method="POST"

--- a/src/routes/(public)/+page.svelte
+++ b/src/routes/(public)/+page.svelte
@@ -154,6 +154,7 @@
 
         <div class="mt-6 md:mt-10 text-sm md:text-lg">
           Tentrait Ltd develops intelligent tools that simplify complex infrastructure challenges — from OT-aware packet analysis to secure access segmentation and scalable SaaS platforms. Built on modern cloud architecture, our solutions empower organisations to visualise, secure, and optimise their operations without disruption.
+          We focus on meeting the UK's latest IT/OT security objectives so you avoid expensive compliance penalties.
         </div>
 
       <div class="mt-6 md:mt-2">

--- a/src/routes/(public)/about/+page.svelte
+++ b/src/routes/(public)/about/+page.svelte
@@ -14,6 +14,9 @@
     <p>
       Tentrait Ltd develops intelligent tools that simplify complex infrastructure challenges — from OT-aware packet analysis to secure access segmentation and scalable SaaS platforms. Built on modern cloud architecture, our solutions empower organisations to visualise, secure, and optimise their operations without disruption.
     </p>
+    <p>
+      We help UK organisations comply with the latest IT/OT security objectives published by the UK government, reducing the risk of costly penalties for non-compliance.
+    </p>
 
     <h2 class="font-bold mt-8 mb-4">About Tentrait Ltd</h2>
     <p>
@@ -56,6 +59,7 @@
       <li><strong>Built by engineers, not marketers</strong> – We solve real problems with real tools, tested in the field.</li>
       <li><strong>Intelligence-first design</strong> – We combine protocol-level insight with usability — not just alerts, but clarity.</li>
       <li><strong>Modern cloud stack</strong> – We leverage the Cloudflare and Azure ecosystems for security, scalability, and cost-efficiency.</li>
+      <li><strong>Compliance built in</strong> – Our tooling aligns with the UK government's latest IT/OT security objectives so you avoid regulatory fines.</li>
       <li><strong>Partner-ready</strong> – We’re built to integrate — with your existing stack, your vendors, and your team.</li>
     </ul>
   </article>

--- a/src/routes/(public)/benefits/+page.svelte
+++ b/src/routes/(public)/benefits/+page.svelte
@@ -15,17 +15,22 @@
       Our cloud‑native platform consolidates your infrastructure, allowing you to scale without large capital expenses.
       Pay only for what you use and eliminate the hidden costs of maintaining on‑premise hardware.
     </p>
+    <p>
+      By meeting the UK government's latest IT/OT security objectives you avoid punitive fines and keep operations running smoothly. Security investments today save money tomorrow.
+    </p>
     <h2 class="font-bold mt-8 mb-4">Reduce Expenses</h2>
     <ul>
       <li>Lower upfront spend by leveraging Cloudflare’s global network.</li>
       <li>Minimise downtime with managed security and monitoring.</li>
       <li>Cut operational overhead through automation and real‑time insight.</li>
+      <li>Avoid fines by adhering to government security objectives for UK businesses.</li>
     </ul>
     <h2 class="font-bold mt-8 mb-4">Boost Revenue</h2>
     <ul>
       <li>Deploy new services faster to capture market opportunities.</li>
       <li>Gain visibility into performance trends to optimise resources.</li>
       <li>Focus on your core business while we handle infrastructure.</li>
+      <li>Prove compliance to win contracts that require strong security.</li>
     </ul>
   </article>
 </div>

--- a/src/routes/(public)/blog/(posts)/awesome-post/+page.svelte
+++ b/src/routes/(public)/blog/(posts)/awesome-post/+page.svelte
@@ -1,26 +1,5 @@
-<p class="lead">A sample post</p>
+<p class="lead">Security investments that pay for themselves</p>
 
-<p>
-  This is a sample blog post to demonstrate the blog engine. It shows some of
-  the formatting options included in the template.
-</p>
+<p>Every breach or compliance failure brings the risk of financial penalties and operational disruption. By following the UK government's security objectives and using tools that expose network blind spots, you reduce that risk dramatically.</p>
 
-<h3>Section Titles are great</h3>
-
-<p>As are more paragraphs.</p>
-
-<blockquote>
-  <p>Block quotes are styled</p>
-</blockquote>
-
-<pre><code class="language-bash"
-    ># Code blocks work too!
-npm install 
-</code></pre>
-
-<p>
-  Check out more formatting options like lists, headers, and more in <a
-    href="https://play.tailwindcss.com/uj1vGACRJA?layout=preview"
-    >the tailwind/typography docs</a
-  >.
-</p>
+<p>Costs saved from avoiding incidents far outweigh the expense of implementing proactive monitoring and access controls. Consider it an insurance policy for your critical infrastructure.</p>

--- a/src/routes/(public)/blog/(posts)/example-post/+page.svelte
+++ b/src/routes/(public)/blog/(posts)/example-post/+page.svelte
@@ -1,26 +1,5 @@
-<p class="lead">A sample post</p>
+<p class="lead">Meeting the UK's new IT/OT security objectives</p>
 
-<p>
-  This is a sample blog post to demonstrate the blog engine. It shows some of
-  the formatting options included in the template.
-</p>
+<p>The UK government recently released updated guidance for securing operational technology. Organisations that proactively comply not only strengthen their defences but also avoid significant fines for non-compliance.</p>
 
-<h3>Section Titles are great</h3>
-
-<p>As are more paragraphs.</p>
-
-<blockquote>
-  <p>Block quotes are styled</p>
-</blockquote>
-
-<pre><code class="language-bash"
-    ># Code blocks work too!
-npm install 
-</code></pre>
-
-<p>
-  Check out more formatting options like lists, headers, and more in <a
-    href="https://play.tailwindcss.com/uj1vGACRJA?layout=preview"
-    >the tailwind/typography docs</a
-  >.
-</p>
+<p>Investing in tooling that maps your infrastructure and highlights weak points is a cost-effective way to stay ahead of regulators. At Tentrait we build exactly that—helping you visualise traffic flows, detect anomalies and prove alignment with government policy.</p>

--- a/src/routes/(public)/blog/(posts)/wonderful-post/+page.svelte
+++ b/src/routes/(public)/blog/(posts)/wonderful-post/+page.svelte
@@ -1,26 +1,5 @@
-<p class="lead">A sample post</p>
+<p class="lead">Aligning OT visibility with government policy</p>
 
-<p>
-  This is a sample blog post to demonstrate the blog engine. It shows some of
-  the formatting options included in the template.
-</p>
+<p>The latest UK IT/OT security objectives emphasise visibility across industrial networks. Our packet analysis service gives you that visibility without disrupting operations.</p>
 
-<h3>Section Titles are great</h3>
-
-<p>As are more paragraphs.</p>
-
-<blockquote>
-  <p>Block quotes are styled</p>
-</blockquote>
-
-<pre><code class="language-bash"
-    ># Code blocks work too!
-npm install 
-</code></pre>
-
-<p>
-  Check out more formatting options like lists, headers, and more in <a
-    href="https://play.tailwindcss.com/uj1vGACRJA?layout=preview"
-    >the tailwind/typography docs</a
-  >.
-</p>
+<p>By continuously monitoring traffic patterns you can demonstrate compliance, mitigate threats early and keep regulators satisfied—all while saving money by avoiding unplanned downtime and fines.</p>

--- a/src/routes/(public)/blog/+page.svelte
+++ b/src/routes/(public)/blog/+page.svelte
@@ -24,7 +24,7 @@
       />
     </a>
   </div>
-  <div class="text-lg text-center">A demo blog with sample content.</div>
+  <div class="text-lg text-center">Articles on staying compliant and avoiding unnecessary security costs.</div>
 
   {#each sorted_blog_posts as post}
     <a href={post.link}>

--- a/src/routes/(public)/blog/posts.js
+++ b/src/routes/(public)/blog/posts.js
@@ -2,7 +2,7 @@ import { WEBSITE_NAME } from "$config";
 
 export const blog_info = {
   name: WEBSITE_NAME + " Blog",
-  description: "A sample blog",
+  description: "Insights on UK IT/OT security compliance and how strong defences save money",
 };
 
 // Update this list with the actual blog post list
@@ -10,20 +10,20 @@ export const blog_info = {
 const blog_posts = [
   {
     title: "Example Blog Post 3",
-    description: "Even more example content, check it out!",
+    description: "Visibility tools for UK OT compliance",
     link: "/blog/wonderful-post",
     date: "2024-01-20",
   },
   {
     title: "Example Blog Post 2",
-    description: "More example content, check it out!",
+    description: "How security spending prevents penalties",
     link: "/blog/awesome-post",
     date: "2023-12-23",
   },
   {
     title: "Example Blog Post",
     description:
-      "A sample blog post, showing the blog post list and individual post pages.",
+      "Meeting the UK's latest IT/OT objectives",
     link: "/blog/example-post",
     date: "2023-11-13",
   },

--- a/src/routes/(public)/contact-us/+page.svelte
+++ b/src/routes/(public)/contact-us/+page.svelte
@@ -107,6 +107,9 @@
         <li>Get a quote</li>
         <li>Answer any technical questions you have</li>
       </ul>
+      <p>
+        Learn how investing in security today helps you comply with the UK's new IT/OT guidelines and prevents costly regulatory penalties.
+      </p>
       <p>Once you complete the form, we'll reach out to you!</p>
       <p class="text-sm pt-8">
         Your information will not be shared with any third parties.

--- a/src/routes/(public)/forgot-password/+page.svelte
+++ b/src/routes/(public)/forgot-password/+page.svelte
@@ -92,6 +92,7 @@
             class="max-w-sm mx-auto p-6 rounded-lg md:card md:card-bordered md:shadow-lg space-y-6 mt-5 min-w-[350px]"
           >
             <h1 class="text-2xl font-bold mb-2">Forgot Password</h1>
+            <p class="text-sm mb-2">We'll help you regain access securely.</p>
             {#if error_message}
               <div role="alert" class="px-2 border-l-4 border-error text-error">
                 {error_message}

--- a/src/routes/(public)/passwordless-sign-in/+page.svelte
+++ b/src/routes/(public)/passwordless-sign-in/+page.svelte
@@ -100,6 +100,7 @@
             class="max-w-sm mx-auto p-6 rounded-lg md:card md:card-bordered md:shadow-lg space-y-6 mt-5 min-w-[350px]"
           >
             <h1 class="text-2xl font-bold mb-2">Passwordless Sign In</h1>
+            <p class="text-sm mb-2">Quick authentication without compromising security.</p>
             <p class="mb-4">
               Don't have an account? <a href="/sign-up" class="underline"
                 >Sign up</a

--- a/src/routes/(public)/sign-in/+page.svelte
+++ b/src/routes/(public)/sign-in/+page.svelte
@@ -84,6 +84,7 @@
           class="max-w-sm mx-auto p-6 rounded-lg md:card md:card-bordered md:shadow-lg space-y-6 mt-5 min-w-[350px]"
         >
           <h1 class="text-2xl font-bold mb-2">Sign In</h1>
+          <p class="text-sm mb-2">Secure access helps keep you compliant with UK IT/OT rules.</p>
           <p class="mb-4">
             Don't have an account? <a href="/sign-up" class="underline"
               >Sign up</a

--- a/src/routes/(public)/sign-up/+page.svelte
+++ b/src/routes/(public)/sign-up/+page.svelte
@@ -158,6 +158,7 @@
             class="max-w-sm mx-auto p-6 rounded-lg md:card md:card-bordered md:shadow-lg space-y-6 mt-5 min-w-[350px]"
           >
             <h1 class="text-2xl font-bold mb-2">Sign Up</h1>
+            <p class="text-sm mb-2">Create an account to secure your operations and stay compliant.</p>
             <p class="mb-4">
               Already have an account? <a href="/sign-in" class="underline"
                 >Sign in</a

--- a/src/routes/(public)/terms/+page.svelte
+++ b/src/routes/(public)/terms/+page.svelte
@@ -8,6 +8,7 @@
     <p class="text-center text-gray-500">Last updated January 01, 2024</p>
 
     <p class="text-center text-error">(For example purpose only)</p>
+    <p class="text-center">Our services are designed to help UK organisations meet current IT/OT security objectives and avoid regulatory penalties.</p>
 
     <h4 class="font-bold mt-8 mb-4">AGREEMENT TO OUR LEGAL TERMS</h4>
     <p class="text-base">We are {WEBSITE_NAME} ("Company," "we," "us," "our"), a company registered in Singapore.</p>

--- a/src/routes/(public)/upload/+page.svelte
+++ b/src/routes/(public)/upload/+page.svelte
@@ -95,6 +95,7 @@
 
 <div class="max-w-2xl mx-auto p-4">
   <h1 class="text-2xl font-bold mb-4">Wireshark Packet Analysis</h1>
+  <p class="mb-2">Upload packet captures to quickly map device interactions and uncover gaps against UK IT/OT security objectives.</p>
   <input type="file" accept=".pcap" on:change={handleFile} class="file-input file-input-bordered" />
   {#if topology}
     <div class="mt-4">


### PR DESCRIPTION
## Summary
- enhance home and marketing pages with UK IT/OT security messaging
- update blog info and example posts for compliance focus
- add brief notes on forms about securing compliance
- clarify terms page with compliance aim

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6843277c9464832dbca181ac7537c83a