### PR TITLE
Move packet analysis page under dashboard

### DIFF
--- a/src/routes/(admin)/dashboard/(menu)/+layout.svelte
+++ b/src/routes/(admin)/dashboard/(menu)/+layout.svelte
@@ -186,6 +186,18 @@
       </li>
       <li>
         <a
+          href="/dashboard/packet-capture"
+          class={dashboard_section === "packet-capture" ? "active" : ""}
+          on:click={close_drawer}
+        >
+          <svg class="h-5 w-5" viewBox="0 0 24 24" stroke="none" fill="none">
+            <path d="M5 12h14M12 5l7 7-7 7" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+          </svg>
+          Packet Capture
+        </a>
+      </li>
+      <li>
+        <a
           href="/dashboard/settings"
           class={dashboard_section === "settings" ? "active" : ""}
           on:click={close_drawer}

--- a/src/routes/(admin)/dashboard/(menu)/packet-capture/+page.svelte
+++ b/src/routes/(admin)/dashboard/(menu)/packet-capture/+page.svelte
@@ -1,6 +1,10 @@
 <script>
+  import { WEBSITE_NAME } from "$config";
+  import { getContext } from "svelte";
   import { parse_pcap } from '$lib/tools/pcap';
   import { onMount, tick } from 'svelte';
+  let dashboard_section = getContext("dashboard_section");
+  dashboard_section.set("packet-capture");
   let file;
   let topology = null;
 
@@ -90,7 +94,7 @@
 </script>
 
 <svelte:head>
-  <title>Packet Upload - Tentrait ltd</title>
+  <title>Packet Capture - {WEBSITE_NAME}</title>
 </svelte:head>
 
 <div class="max-w-2xl mx-auto p-4">

--- a/src/routes/(public)/+layout.svelte
+++ b/src/routes/(public)/+layout.svelte
@@ -22,7 +22,7 @@
         <a href="/benefits" class="btn btn-ghost text-base font-bold">Benefits</a>
       </li>
       <li class="sm:mx-1">
-        <a href="/upload" class="btn btn-ghost text-base font-bold">Packet Upload</a>
+        <a href="/dashboard/packet-capture" class="btn btn-ghost text-base font-bold">Packet Upload</a>
       </li>
       <li class="sm:mx-1">
         <a href="/pricing" class="btn btn-ghost text-base font-bold">Pricing</a>
@@ -73,7 +73,7 @@
           <a href="/benefits" class="btn btn-ghost text-base font-bold">Benefits</a>
         </li>
         <li>
-          <a href="/upload" class="btn btn-ghost text-base font-bold">Packet Upload</a>
+          <a href="/dashboard/packet-capture" class="btn btn-ghost text-base font-bold">Packet Upload</a>
         </li>
         <li>
           <a href="/pricing" class="btn btn-ghost text-base font-bold"
@@ -113,7 +113,7 @@
         <a class="link link-hover my-1" href="/blog">Blog</a>
         <a class="link link-hover my-1" href="/about">About</a>
         <a class="link link-hover my-1" href="/benefits">Benefits</a>
-        <a class="link link-hover my-1" href="/upload">Packet Upload</a>
+        <a class="link link-hover my-1" href="/dashboard/packet-capture">Packet Upload</a>
       <a class="link link-hover my-1" href="/contact-us">Contact Us</a>
       <a
         class="link link-hover my-1"

--- a/src/routes/(public)/upload/+page.server.js
+++ b/src/routes/(public)/upload/+page.server.js
@@ -1,0 +1,6 @@
+import { redirect } from '@sveltejs/kit';
+
+/** @type {import('./$types').PageServerLoad} */
+export function load() {
+  throw redirect(303, '/dashboard/packet-capture');
+}


### PR DESCRIPTION
## Summary
- move packet upload page to `/dashboard/packet-capture`
- redirect old `/upload` page to the new dashboard route
- link to the new packet capture page from the public layout
- show Packet Capture entry in dashboard menu

## Testing
- `npm test` *(fails: Cannot find package '@tsndr/cloudflare-worker-jwt')*

------
https://chatgpt.com/codex/tasks/task_e_68432c0c5984832dbb3cd2907c5b53ab