### PR TITLE
Add protected members area

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,7 @@ After the steps above, you’ll have a working version like the demo page. Howev
 - Functionality
   - Add actual functionality for your service.
   - Replace the dashboard with real content (`/src/routes/(admin)/dashboard/(menu)/+page.svelte`).
+  - Customize the membership area (`/src/routes/(admin)/membership/+page.svelte`).
   - Add necessary documentation pages for your service.
 
 ## Icons

--- a/src/hooks.server.js
+++ b/src/hooks.server.js
@@ -7,7 +7,7 @@ import { get_login_session } from "$lib/server/session";
 
 const app_env = dev ? "development" : "production";
 const place = "hooks";
-const protected_routes = ["/dashboard"];
+const protected_routes = ["/dashboard", "/membership"];
 
 /*
   login_auth_token is a signed JWT (with payload: uuid), which is stored in cookie and used as session_id (key in KV and db).
@@ -30,7 +30,9 @@ export async function handle({ event, resolve }) {
   log_message(event.platform, app_env, place, "info", "hook start, to page: " + event.url.pathname);
 
   const login_auth_token = event.cookies.get("login_auth_token");
-  const is_protected_route = event.url.pathname.includes(protected_routes);
+  const is_protected_route = protected_routes.some((route) =>
+    event.url.pathname.startsWith(route)
+  );
   // /dashboard, /dashboard/*, /dashboard/anything => protected
 
   if (is_protected_route && !login_auth_token) {

--- a/src/routes/(admin)/membership/+page.server.js
+++ b/src/routes/(admin)/membership/+page.server.js
@@ -1,0 +1,14 @@
+import { dev } from "$app/environment";
+import { redirect } from "@sveltejs/kit";
+import { log_message } from "$lib/server/log";
+
+const place = "/membership";
+const app_env = dev ? "development" : "production";
+
+export async function load({ locals, platform }) {
+  log_message(platform, app_env, place, "info", "page load start.");
+  if (locals.user) {
+    return { user: locals.user };
+  }
+  redirect(303, "/sign-in");
+}

--- a/src/routes/(admin)/membership/+page.svelte
+++ b/src/routes/(admin)/membership/+page.svelte
@@ -1,0 +1,16 @@
+<script>
+  import "$appcss";
+  import { WEBSITE_NAME } from "$config";
+  export let data;
+  const { user } = data;
+</script>
+
+<svelte:head>
+  <title>Members Area - {WEBSITE_NAME}</title>
+</svelte:head>
+
+<div class="container mx-auto py-8">
+  <h1 class="text-3xl font-bold mb-4">Welcome to the Members Area</h1>
+  <p class="mb-2">Hello {user.nickname}, you have successfully accessed the protected members area.</p>
+  <p>Only logged-in users can see this content.</p>
+</div>

--- a/src/routes/(public)/+layout.svelte
+++ b/src/routes/(public)/+layout.svelte
@@ -28,6 +28,9 @@
         <a href="/pricing" class="btn btn-ghost text-base font-bold">Pricing</a>
       </li>
       <li class="sm:mx-1">
+        <a href="/membership" class="btn btn-ghost text-base font-bold">Members Area</a>
+      </li>
+      <li class="sm:mx-1">
         <a
           href="/sign-in"
           class="btn btn-outline btn-primary text-base font-bold">Sign In</a
@@ -81,6 +84,10 @@
           >
         </li>
         <li>
+          <a href="/membership" class="btn btn-ghost text-base font-bold"
+            >Members Area</a>
+        </li>
+        <li>
           <a
             href="/sign-in"
             class="btn btn-outline btn-primary text-base font-bold">Sign In</a
@@ -110,7 +117,8 @@
     <nav>
       <span class="footer-title opacity-80">Explore</span>
       <a class="link link-hover my-1" href="/pricing">Pricing</a>
-        <a class="link link-hover my-1" href="/blog">Blog</a>
+      <a class="link link-hover my-1" href="/membership">Members Area</a>
+      <a class="link link-hover my-1" href="/blog">Blog</a>
         <a class="link link-hover my-1" href="/about">About</a>
         <a class="link link-hover my-1" href="/benefits">Benefits</a>
         <a class="link link-hover my-1" href="/dashboard/packet-capture">Packet Upload</a>


### PR DESCRIPTION
## Summary
- add new members area under `(admin)` routes
- protect `/membership` path in hooks
- expose members area link in public navigation and footer
- mention customizing membership page in README
- fix protected routes check logic

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68432e0c5444832d8f59ab91c6129aa3