### PR TITLE
Add security news feed

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ You are highly recommended to explore all the features using the fully functiona
 
 - SEO Friendly: Server-Side Rendering, SEO metadata, Blog and RSS feed.
 
-- Media Feed: Aggregates the latest IT/OT security headlines from public RSS feeds.
+- Media Feed: Aggregates the latest IT/OT security headlines from public RSS feeds and displays them on the `/news` page.
 
 - Highly Customizable: Less dependencies used, easy to modify, and extend. No auth library used, DIY for better control.
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ You are highly recommended to explore all the features using the fully functiona
 
 - SEO Friendly: Server-Side Rendering, SEO metadata, Blog and RSS feed.
 
+- Media Feed: Aggregates the latest IT/OT security headlines from public RSS feeds.
+
 - Highly Customizable: Less dependencies used, easy to modify, and extend. No auth library used, DIY for better control.
 
 - Responsive: Design for both desktop and mobile, responsive layout, and components.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@tsndr/cloudflare-worker-jwt": "^2.5.3",
         "bcryptjs": "^2.4.3",
+        "fast-xml-parser": "^5.2.4",
         "i18n-iso-countries": "^7.11.2",
         "stripe": "^16.2.0",
         "svelte-french-toast": "^1.2.0",
@@ -1730,6 +1731,24 @@
         "node": ">=8.6.0"
       }
     },
+    "node_modules/fast-xml-parser": {
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.4.tgz",
+      "integrity": "sha512-6mNrAVwHip2nGyPYn6xQJK/znBbIoz6to5VMNysrka1/aoSylbB8vjYgkpaFp05EFojiflVV+3QzXe9Ap3Esng==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "strnum": "^2.1.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/fastparse": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.2.tgz",
@@ -3210,6 +3229,18 @@
       "engines": {
         "node": ">=12.*"
       }
+    },
+    "node_modules/strnum": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.1.tgz",
+      "integrity": "sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/sucrase": {
       "version": "3.35.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@tsndr/cloudflare-worker-jwt": "^2.5.3",
         "bcryptjs": "^2.4.3",
-        "fast-xml-parser": "^5.2.4",
+        "fast-xml-parser": "^4.5.3",
         "i18n-iso-countries": "^7.11.2",
         "stripe": "^16.2.0",
         "svelte-french-toast": "^1.2.0",
@@ -1732,9 +1732,9 @@
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.2.4",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.4.tgz",
-      "integrity": "sha512-6mNrAVwHip2nGyPYn6xQJK/znBbIoz6to5VMNysrka1/aoSylbB8vjYgkpaFp05EFojiflVV+3QzXe9Ap3Esng==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.3.tgz",
+      "integrity": "sha512-RKihhV+SHsIUGXObeVy9AXiBbFwkVk7Syp8XgwN5U3JV416+Gwp/GO9i0JYKmikykgz/UHRrrV4ROuZEo/T0ig==",
       "funding": [
         {
           "type": "github",
@@ -1743,7 +1743,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "strnum": "^2.1.0"
+        "strnum": "^1.1.1"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -3231,9 +3231,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.1.tgz",
-      "integrity": "sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.1.2.tgz",
+      "integrity": "sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "@tsndr/cloudflare-worker-jwt": "^2.5.3",
     "bcryptjs": "^2.4.3",
+    "fast-xml-parser": "^4.5.3",
     "i18n-iso-countries": "^7.11.2",
     "stripe": "^16.2.0",
     "svelte-french-toast": "^1.2.0",

--- a/src/routes/(public)/+layout.svelte
+++ b/src/routes/(public)/+layout.svelte
@@ -16,6 +16,9 @@
         <a href="/blog" class="btn btn-ghost text-base font-bold">Blog</a>
       </li>
       <li class="sm:mx-1">
+        <a href="/news" class="btn btn-ghost text-base font-bold">News</a>
+      </li>
+      <li class="sm:mx-1">
         <a href="/about" class="btn btn-ghost text-base font-bold">About</a>
       </li>
       <li class="sm:mx-1">
@@ -63,12 +66,15 @@
         tabindex="0"
         class="menu menu-lg dropdown-content mt-3 z-[1] p-2 shadow bg-base-100 rounded-box w-40 font-bold space-y-1"
       >
-        <li>
-          <a href="/blog" class="btn btn-ghost text-base font-bold">Blog</a>
-        </li>
-        <li>
-          <a href="/about" class="btn btn-ghost text-base font-bold">About</a>
-        </li>
+      <li>
+        <a href="/blog" class="btn btn-ghost text-base font-bold">Blog</a>
+      </li>
+      <li>
+        <a href="/news" class="btn btn-ghost text-base font-bold">News</a>
+      </li>
+      <li>
+        <a href="/about" class="btn btn-ghost text-base font-bold">About</a>
+      </li>
         <li>
           <a href="/benefits" class="btn btn-ghost text-base font-bold">Benefits</a>
         </li>
@@ -111,6 +117,7 @@
       <span class="footer-title opacity-80">Explore</span>
       <a class="link link-hover my-1" href="/pricing">Pricing</a>
         <a class="link link-hover my-1" href="/blog">Blog</a>
+        <a class="link link-hover my-1" href="/news">News</a>
         <a class="link link-hover my-1" href="/about">About</a>
         <a class="link link-hover my-1" href="/benefits">Benefits</a>
         <a class="link link-hover my-1" href="/dashboard/packet-capture">Packet Upload</a>

--- a/src/routes/(public)/news/+page.server.js
+++ b/src/routes/(public)/news/+page.server.js
@@ -1,0 +1,33 @@
+import { XMLParser } from 'fast-xml-parser';
+
+/** @type {import('./$types').PageServerLoad} */
+export async function load({ fetch }) {
+  const feeds = [
+    'https://www.cisa.gov/sites/default/files/feeds/ics-advisories.xml',
+    'https://www.securityweek.com/category/ics/feed/'
+  ];
+  const parser = new XMLParser();
+  const news = [];
+
+  for (const url of feeds) {
+    try {
+      const res = await fetch(url);
+      const text = await res.text();
+      const data = parser.parse(text);
+      let items = data.rss?.channel?.item || [];
+      if (!Array.isArray(items)) items = [items];
+      for (const item of items.slice(0, 5)) {
+        news.push({
+          title: item.title,
+          link: Array.isArray(item.link) ? item.link[0] : item.link,
+          pubDate: item.pubDate
+        });
+      }
+    } catch (e) {
+      console.error('Failed to load feed ' + url, e);
+    }
+  }
+
+  news.sort((a, b) => new Date(b.pubDate) - new Date(a.pubDate));
+  return { news };
+}

--- a/src/routes/(public)/news/+page.svelte
+++ b/src/routes/(public)/news/+page.svelte
@@ -1,0 +1,30 @@
+<script>
+  export let data;
+</script>
+
+<svelte:head>
+  <title>Security News</title>
+  <meta name="description" content="Latest IT/OT security headlines" />
+</svelte:head>
+
+<div class="py-8 lg:py-12 px-6 max-w-2xl mx-auto">
+  <h1 class="text-3xl lg:text-5xl font-medium text-primary text-center mb-6">
+    IT/OT Security News
+  </h1>
+  {#if data.news.length === 0}
+    <p>No news available.</p>
+  {:else}
+    <ul class="space-y-4">
+      {#each data.news as item}
+        <li class="border-b pb-2">
+          <a href={item.link} target="_blank" rel="noreferrer" class="text-lg text-primary underline">
+            {item.title}
+          </a>
+          <div class="text-sm text-slate-500">
+            {new Date(item.pubDate).toLocaleDateString('en-GB', { year: 'numeric', month: 'short', day: 'numeric' })}
+          </div>
+        </li>
+      {/each}
+    </ul>
+  {/if}
+</div>

--- a/src/routes/(public)/news/+page.svelte
+++ b/src/routes/(public)/news/+page.svelte
@@ -17,7 +17,7 @@
     <ul class="space-y-4">
       {#each data.news as item}
         <li class="border-b pb-2">
-          <a href={item.link} target="_blank" rel="noreferrer" class="text-lg text-primary underline">
+          <a href={item.link} target="_blank" rel="noopener noreferrer" class="text-lg text-primary underline">
             {item.title}
           </a>
           <div class="text-sm text-slate-500">


### PR DESCRIPTION
## Summary
- aggregate IT/OT security news from public RSS feeds
- display the feed at `/news`
- link new page in the navigation
- document the media feed feature

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68432ec69804832da65227d531ca437e